### PR TITLE
Include Node.js 16.x in CI workflow

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x] # Temporarily remove 16.x
+        node-version: [16.x, 18.x]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Update the CI workflow to include Node.js version 16.x alongside 18.x for testing compatibility.